### PR TITLE
Fix Keras serialization for losses and NeuralDecisionTree

### DIFF
--- a/src/centimators/losses.py
+++ b/src/centimators/losses.py
@@ -16,8 +16,10 @@ Highlights:
 import keras.ops as K
 from keras.losses import Loss
 from keras.config import epsilon
+from keras.saving import register_keras_serializable
 
 
+@register_keras_serializable(package="centimators")
 class SpearmanCorrelation(Loss):
     """Differentiable Spearman rank correlation loss.
 
@@ -114,7 +116,13 @@ class SpearmanCorrelation(Loss):
 
         return numerator / denominator
 
+    def get_config(self):
+        config = super().get_config()
+        config.update({"regularization_strength": self.regularization_strength})
+        return config
 
+
+@register_keras_serializable(package="centimators")
 class CombinedLoss(Loss):
     """Weighted combination of MSE and Spearman correlation losses.
 
@@ -168,3 +176,14 @@ class CombinedLoss(Loss):
         spearman = self.spearman_loss(y_true, y_pred)
 
         return self.mse_weight * mse + self.spearman_weight * spearman
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "mse_weight": self.mse_weight,
+                "spearman_weight": self.spearman_weight,
+                "spearman_regularization": self.spearman_loss.regularization_strength,
+            }
+        )
+        return config


### PR DESCRIPTION
- Add @register_keras_serializable and get_config() to SpearmanCorrelation
- Add @register_keras_serializable and get_config() to CombinedLoss
- Add @register_keras_serializable and get_config() to NeuralDecisionTree
- Replace lambda initializer with Constant() in NeuralDecisionTree

Fixes pickle/model.save() for all custom Keras classes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves Keras save/load compatibility for custom components.
> 
> - Adds `@register_keras_serializable` and `get_config()` to `SpearmanCorrelation` and `CombinedLoss` (exposes `regularization_strength`, `mse_weight`, `spearman_weight`, `spearman_regularization`)
> - Adds `@register_keras_serializable`, `**kwargs` passthrough, stored init params, and `get_config()` to `NeuralDecisionTree`
> - Replaces lambda initializer with `initializers.Constant` for `temperature` and feature mask weights
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f54f200be3c6bc7f789f987e7c317a978fd4cf0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->