### PR TITLE
fix: use numpy reshape instead of keras.ops.reshape in SequenceEstimator

### DIFF
--- a/src/centimators/model_estimators/keras_estimators/sequence.py
+++ b/src/centimators/model_estimators/keras_estimators/sequence.py
@@ -10,7 +10,7 @@ from sklearn.preprocessing import StandardScaler
 import numpy
 
 from .base import BaseKerasEstimator, _ensure_numpy
-from keras import ops, layers, models
+from keras import layers, models
 
 
 @dataclass(kw_only=True)
@@ -25,15 +25,14 @@ class SequenceEstimator(BaseKerasEstimator):
 
     def _reshape(self, X: IntoFrame, validation_data: tuple[Any, Any] | None = None):
         X = _ensure_numpy(X)
-        X_reshaped = ops.reshape(
-            X, (X.shape[0], self.seq_length, self.n_features_per_timestep)
+        X_reshaped = X.reshape(
+            (X.shape[0], self.seq_length, self.n_features_per_timestep)
         )
 
         if validation_data:
             X_val, y_val = validation_data
             X_val = _ensure_numpy(X_val)
-            X_val_reshaped = ops.reshape(
-                X_val,
+            X_val_reshaped = X_val.reshape(
                 (X_val.shape[0], self.seq_length, self.n_features_per_timestep),
             )
             validation_data = X_val_reshaped, _ensure_numpy(y_val)


### PR DESCRIPTION
Fixes #5 - torch backend LSTMRegressor fit fails with CUDA tensors.

The issue was that `ops.reshape()` converts numpy arrays to backend tensors. With torch backend + CUDA GPU, this creates CUDA tensors that `numpy.asarray()` cannot convert back, causing the error: "can't convert cuda:0 device type tensor to numpy"

The fix uses numpy's native `reshape()` method instead, keeping data as numpy arrays until `model.fit()` where Keras handles the conversion internally. This matches the pattern used by other estimators (dense.py, autoencoder.py, tree.py) which don't use keras.ops for preprocessing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces Keras `ops.reshape` with NumPy `reshape` in `SequenceEstimator` to keep data as NumPy arrays during preprocessing and avoid unintended backend tensor conversion (e.g., CUDA tensors with Torch backend).
> 
> - Update `_reshape` to call `X.reshape(...)` and similarly for validation data; return unchanged API
> - Remove unused `keras.ops` import
> - Keeps prediction path intact; only reshaping logic changed prior to `model.fit()`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa223a9f40b70bde8b8397284f89cb2e2c784a5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->